### PR TITLE
updates render and app.go to be able to use fingerprinted assets

### DIFF
--- a/actions/app.go
+++ b/actions/app.go
@@ -81,7 +81,7 @@ func App() *buffalo.App {
 		app.GET("/rss", RSSFeed)
 		app.Middleware.Skip(Authorize, HomeHandler, RSSFeed)
 
-		app.ServeFiles("/assets", packr.NewBox("../public/assets"))
+		app.ServeFiles("/assets", assetsBox)
 
 		auth := app.Group("/auth")
 		gothwap := buffalo.WrapHandlerFunc(gothic.BeginAuthHandler)

--- a/actions/render.go
+++ b/actions/render.go
@@ -14,14 +14,17 @@ import (
 )
 
 var r *render.Engine
+var assetsBox = packr.NewBox("../public/assets")
 
 func init() {
+
 	r = render.New(render.Options{
 		// HTML layout to be used for all HTML requests:
 		HTMLLayout: "application.html",
 
 		// Box containing all of the templates:
 		TemplatesBox: packr.NewBox("../templates"),
+		AssetsBox:    assetsBox,
 
 		// Add template helpers here:
 		Helpers: render.Helpers{

--- a/templates/application.html
+++ b/templates/application.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Golang Flow</title>
-  <link rel="stylesheet" href="/assets/application.css" type="text/css" media="all" />
+  <%= stylesheetTag("application.css") %>
   
   <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -83,7 +83,9 @@
       </center>
     </div>
   <br />
-  <script src="/assets/application.js" type="text/javascript" charset="utf-8"></script>
+
+  <%= javascriptTag("application.js") %>
+
   <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-59cc8bbb05397177"></script> 
   <script type="text/javascript">
     var _gauges = _gauges || [];


### PR DESCRIPTION
@bscott this should solve the asset rendering part, however it seems there are some js dependencies that are missing causing webpack compilation to fail.