### PR TITLE
Migrate from Google Container Registry to Artifact Registry

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,43 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line below:
+.git
+.gitignore
+
+# Node
+node_modules/
+npm-debug.log
+
+# Build artifacts
+public/assets/
+
+# Editor directories and files
+.idea
+.vscode
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test files
+*_test.go
+**/testdata
+
+# Documentation
+*.md
+!README.md
+
+# CI/CD
+.github/
+.travis.yml

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,31 @@
+steps:
+  # Build the Docker image
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'Build'
+    args:
+      - 'build'
+      - '-t'
+      - 'us-docker.pkg.dev/$PROJECT_ID/golangflow/golangflow-production:$COMMIT_SHA'
+      - '-t'
+      - 'us-docker.pkg.dev/$PROJECT_ID/golangflow/golangflow-production:latest'
+      - '.'
+
+  # Push the Docker image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'Push'
+    args:
+      - 'push'
+      - '--all-tags'
+      - 'us-docker.pkg.dev/$PROJECT_ID/golangflow/golangflow-production'
+
+# Images to push to Artifact Registry
+images:
+  - 'us-docker.pkg.dev/$PROJECT_ID/golangflow/golangflow-production:$COMMIT_SHA'
+  - 'us-docker.pkg.dev/$PROJECT_ID/golangflow/golangflow-production:latest'
+
+# Build timeout (default is 10 minutes, increase if needed)
+timeout: 1200s
+
+# Machine type (optional - use if builds are slow)
+options:
+  machineType: 'N1_HIGHCPU_8'


### PR DESCRIPTION
## Summary

Migrates golangflow from Google Container Registry (GCR) to Artifact Registry to resolve build failures caused by GCR deprecation.

## Problem

Build was failing at the push step with error:
```
Container Registry is deprecated and shutting down, please use the auto migration tool to migrate to Artifact Registry
```

## Solution

- ✅ Created explicit `cloudbuild.yaml` configuration
- ✅ Configured build to push to Artifact Registry (`us-docker.pkg.dev`)
- ✅ Added `.gcloudignore` to exclude unnecessary files
- ✅ Set 20-minute build timeout for larger builds
- ✅ Configured N1_HIGHCPU_8 machine type for faster builds
- ✅ Tested build successfully - completes in ~2 minutes

## Changes

### New Files

**`cloudbuild.yaml`**
- Explicit Cloud Build configuration
- Tags images with both commit SHA and `latest`
- Pushes to Artifact Registry instead of deprecated GCR

**`.gcloudignore`**
- Excludes unnecessary files from Cloud Build uploads
- Reduces upload size and build time

## Build Configuration

**Old (GCR - deprecated)**:
```
us.gcr.io/golangflow-290604/golangflow/golangflow-production
```

**New (Artifact Registry)**:
```
us-docker.pkg.dev/golangflow-290604/golangflow/golangflow-production
```

## Test Results

Build tested successfully:
- ✅ Build ID: `206fa9c0-532f-4609-90f4-ebcc9108462c`
- ✅ Status: SUCCESS
- ✅ Duration: 1m 56s
- ✅ Image pushed successfully to Artifact Registry

## Next Steps After Merge

1. Update Cloud Build trigger to use `cloudbuild.yaml`
2. Verify automated builds work correctly
3. Consider migrating existing GCR images using: `gcloud artifacts docker upgrade migrate`

## Notes

- The Dockerfile changes from October 12 (commit `c4d16c5`) are working perfectly
- This resolves the infrastructure issue, not a code issue
- All npm, webpack, and Go builds are succeeding