### PR TITLE
Fix Cloud Run deployment issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ WORKDIR /bin/
 # Copy the built binary from builder stage
 COPY --from=builder /bin/app .
 
+# Copy database configuration file
+COPY --from=builder /app/database.yml .
+
 # Cloud Run expects the container to listen on $PORT
 EXPOSE 8080
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,6 +18,18 @@ steps:
       - '--all-tags'
       - 'us-docker.pkg.dev/$PROJECT_ID/golangflow/golangflow-production'
 
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'Deploy'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'golangflow-production'
+      - '--image=us-docker.pkg.dev/$PROJECT_ID/golangflow/golangflow-production:$COMMIT_SHA'
+      - '--region=us-west1'
+      - '--platform=managed'
+
 # Images to push to Artifact Registry
 images:
   - 'us-docker.pkg.dev/$PROJECT_ID/golangflow/golangflow-production:$COMMIT_SHA'


### PR DESCRIPTION
## Summary
- Fixes container startup error: `unable to find pop config file`
- Adds Cloud Run deployment step to use new Artifact Registry images
- Ensures environment variables are preserved across deployments

## Changes

### Dockerfile
- Added `database.yml` copy to final container image
- Buffalo's Pop ORM requires this file to configure database connections

### cloudbuild.yaml  
- Added Cloud Run deployment step after image push
- Deploys from Artifact Registry (`us-docker.pkg.dev`) instead of deprecated GCR
- Uses `$COMMIT_SHA` tag for deployments

## Testing
Once merged, the automated Cloud Build trigger will:
1. Build Docker image with database.yml included
2. Push to Artifact Registry
3. Deploy to Cloud Run with new image

All existing environment variables (ADMIN_*, DATABASE_URL, etc.) will be preserved as they're stored in the Cloud Run service configuration, not in the image.

## Fixes
- Container failing to start with "unable to find pop config file"
- Deployment using old GCR image location