### PR TITLE
Fix template loading with TemplateBaseDir

### DIFF
--- a/actions/render.go
+++ b/actions/render.go
@@ -30,8 +30,9 @@ func initRender() {
 		HTMLLayout: "application.html",
 
 		// Embedded filesystems for templates and assets:
-		TemplatesFS: templatesFS,
-		AssetsFS:    assetsFS,
+		TemplatesFS:     templatesFS,
+		TemplateBaseDir: "templates",
+		AssetsFS:        assetsFS,
 
 		// Add template helpers here:
 		// https://github.com/gobuffalo/plush/issues/111


### PR DESCRIPTION
## Summary
- Adds TemplateBaseDir to render.Options to properly strip the templates/ prefix
- Fixes "could not find template index.html" error

## Root Cause
When using `//go:embed templates/*`, files are embedded WITH the templates/ prefix. Buffalo's render engine was looking for "index.html" but it was actually at "templates/index.plush.html" in the embedded FS.

## Solution  
Set `TemplateBaseDir: "templates"` to tell Buffalo to look for templates within the templates/ subdirectory of the embedded FS.

## Testing
Once merged, the site should load properly without template errors.