### PR TITLE
Add date sort to the homepage

### DIFF
--- a/actions/home.go
+++ b/actions/home.go
@@ -22,10 +22,10 @@ func HomeHandler(c buffalo.Context) error {
 	posts := &models.Posts{}
 
 	q := tx.PaginateFromParams(c.Request().URL.Query())
-	// You can order your list here. Just change
-	err := q.Order("created_at desc").All(posts)
-	// to:
-	// err := tx.Order("create_at desc").All(posts)
+	// Sort by post date. "?sort=oldest" shows the oldest posts first;
+	// anything else (including no param) defaults to newest first.
+	sort := c.Param("sort")
+	err := q.Order(models.PostsOrder(sort)).All(posts)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -33,6 +33,8 @@ func HomeHandler(c buffalo.Context) error {
 	// Make posts available inside the html template
 	c.Set("posts", posts)
 	c.Set("pagination", q.Paginator)
+	// Expose the active sort so the template can highlight it.
+	c.Set("sort", sort)
 	return c.Render(200, r.HTML("index.html"))
 }
 

--- a/models/post.go
+++ b/models/post.go
@@ -29,6 +29,21 @@ func (p Post) String() string {
 // Posts is not required by pop and may be deleted
 type Posts []Post
 
+// PostsOrder returns the SQL "ORDER BY" clause for the homepage post list
+// given a requested sort direction. It powers the date sort on the homepage.
+//
+// Supported values:
+//   - "oldest" -> oldest posts first (created_at asc)
+//   - anything else, including "newest" and "" -> newest posts first (created_at desc)
+//
+// It is a pure function so it can be unit-tested without a database.
+func PostsOrder(sort string) string {
+	if sort == "oldest" {
+		return "created_at asc"
+	}
+	return "created_at desc"
+}
+
 // String is not required by pop and may be deleted
 func (p Posts) String() string {
 	jp, _ := json.Marshal(p)

--- a/models/postsorder_test.go
+++ b/models/postsorder_test.go
@@ -1,0 +1,23 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/bscott/golangflow/models"
+)
+
+// TestPostsOrder covers the homepage date-sort helper. It is a pure function,
+// so it runs without a Buffalo runtime or a database.
+func TestPostsOrder(t *testing.T) {
+	cases := map[string]string{
+		"oldest":  "created_at asc",
+		"newest":  "created_at desc",
+		"":        "created_at desc",
+		"garbage": "created_at desc",
+	}
+	for in, want := range cases {
+		if got := models.PostsOrder(in); got != want {
+			t.Errorf("PostsOrder(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/templates/index.plush.html
+++ b/templates/index.plush.html
@@ -1,3 +1,13 @@
+<div class="row">
+  <div class="col-md-12" style="text-align: right">
+    Sort by date:
+    <%= if (sort == "oldest") { %>
+      <a href="/?sort=newest">Newest</a> | <strong>Oldest</strong>
+    <% } else { %>
+      <strong>Newest</strong> | <a href="/?sort=oldest">Oldest</a>
+    <% } %>
+  </div>
+</div>
 <%= for (post) in posts { %>
 <div class="post-Content">
   <div class="row">


### PR DESCRIPTION
## What

Adds a date sort toggle to the homepage. Previously posts were always listed newest-first with no way to change the order.

The sort is driven by a `?sort=` query param:
- `?sort=oldest` -> oldest posts first (`created_at asc`)
- default / `?sort=newest` -> newest posts first (`created_at desc`)

## Changes

- **`models/post.go`** — `PostsOrder(sort string) string`, a pure helper that maps the sort param to a SQL `ORDER BY` clause.
- **`actions/home.go`** — `HomeHandler` orders the list via `models.PostsOrder(sort)` and sets the active `sort` in the render context.
- **`templates/index.plush.html`** — a "Sort by date: Newest | Oldest" control that links to each order and bolds the active one.

## Tests

Test categories:
- **Model logic / pure functions** — `TestPostsOrder` added (`models/postsorder_test.go`), covers `oldest`, `newest`, empty, and unknown inputs. Runs with no Buffalo runtime or DB. **Ran locally: PASS.**
- **Handlers / integration / routing / middleware / assets** — N/A here; the handler change is a thin call into the tested pure helper plus a template variable. The end-to-end handler assertion belongs in the Buffalo `ActionSuite` (needs Buffalo CLI + live Postgres) and defers to maintainer CI.

`go test ./models/ -run TestPostsOrder` and `go build ./actions/` pass locally with a portable Go toolchain. The full Buffalo suite defers to maintainer CI.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)